### PR TITLE
[Fix] More visible image.

### DIFF
--- a/IOSHelper/UIImage+Helpers.m
+++ b/IOSHelper/UIImage+Helpers.m
@@ -33,12 +33,12 @@
 // リサイズ
 -(UIImage *)resizeScale : (float) scale{
     CGSize rs = CGSizeMake(self.size.width * scale, self.size.height * scale);
-    
-    UIGraphicsBeginImageContext(rs);
+
+    UIGraphicsBeginImageContextWithOptions(rs, NO, 0.0);
     [self drawInRect:CGRectMake(0, 0, rs.width, rs.height)];
     UIImage* new = UIGraphicsGetImageFromCurrentImageContext();
     UIGraphicsEndImageContext();
-    
+
     return new;
 }
 


### PR DESCRIPTION
iPhone6sで画像を縮小表示した際に画像がぼやけていたため対応しました。
ご確認の程、お願い致します。
